### PR TITLE
Revert "wait for task definition"

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,9 +14,4 @@ resource "aws_ecs_service" "this" {
     subnets          = var.subnets
     assign_public_ip = var.assign_public_ip
   }
-
-  // wait for task definition
-  provisioner "local-exec" {
-    command = "sleep 10"
-  }
 }


### PR DESCRIPTION
Reverts voyagegroup/terraform-ecs-task-sequential-execution#1

こういう感じのことをすればよさそう。

```
resource "null_resource" "update-service" {
  triggers = {
    arn = module.mongo-task-definition.arn
  }

  provisioner "local-exec" {
    command = "aws ecs update-service --cluster ${aws_ecs_service.mongo.cluster} --service ${aws_ecs_service.mongo.name} --task-definition ${module.mongo-task-definition.arn} --force-new-deployment"
  }
}
```