### PR TITLE
set null version

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,3 @@
+provider null {
+  version = "~> 2.1"
+}


### PR DESCRIPTION
```
To prevent automatic upgrades to new major versions that may contain breaking
changes, it is recommended to add version = "..." constraints to the
corresponding provider blocks in configuration, with the constraint strings
suggested below.

* provider.null: version = "~> 2.1"
```