### PR TITLE
delete quote

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ resource aws_ecs_service this {
   }
 
   lifecycle {
-    ignore_changes = ["task_definition"]
+    ignore_changes = [task_definition]
   }
 
   tags = var.tags


### PR DESCRIPTION
```
Warning: Quoted references are deprecated

  on .terraform/modules/exec/main.tf line 15, in resource "aws_ecs_service" "this":
  15:     ignore_changes = ["task_definition"]

In this context, references are expected literally rather than in quotes.
Terraform 0.11 and earlier required quotes, but quoted references are now
deprecated and will be removed in a future version of Terraform. Remove the
quotes surrounding this reference to silence this warning.

```